### PR TITLE
Check for compatible ARM GCC toolchain version.

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -4,6 +4,28 @@ project(MetaModulePluginSDK LANGUAGES C CXX ASM)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/version.cmake)
 
+# Check ARM GCC toolchain version compatibility
+message(STATUS "DEBUG: CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "DEBUG: CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "12.3.99")
+        message(FATAL_ERROR
+            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.\n"
+            "The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3.\n"
+            "Newer versions have incompatibilities with the bundled libstdc++ implementation.\n"
+            "Download the correct version from:\n"
+            "  https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads\n"
+            "Or specify the toolchain path with:\n"
+            "  cmake -DTOOLCHAIN_BASE_DIR=/path/to/arm-toolchain-12.3/bin ...")
+    endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.2.0")
+        message(WARNING
+            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is older than the tested version.\n"
+            "The MetaModule Plugin SDK is designed for ARM GNU Toolchain 12.2 or 12.3.\n"
+            "Build may fail or produce unexpected results.")
+    endif()
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/ccache.cmake)

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -8,11 +8,11 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/version.cmake)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.2.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.4.0"))
         message(FATAL_ERROR
-            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.\n"
-            "The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3.\n"
-            "Download the correct version from:\n"
-            "  https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads\n"
-            "Specify the toolchain path with:\n"
+            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported."
+            "The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3."
+            "Download the correct version from:"
+            "  https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
+            "Specify the toolchain path with:"
             "  cmake -DTOOLCHAIN_BASE_DIR=/path/to/arm-toolchain-12.3/bin ...")
     endif()
 endif()

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -8,12 +8,12 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/version.cmake)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.2.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.4.0"))
         message(FATAL_ERROR
-            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported."
-            "The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3."
-            "Download the correct version from:"
-            "  https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads"
-            "Specify the toolchain path with:"
-            "  cmake -DTOOLCHAIN_BASE_DIR=/path/to/arm-toolchain-12.3/bin ...")
+            " ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported."
+            " The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3.\n"
+            " Download the correct version from:\n"
+            "   https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads\n"
+            " Specify the toolchain path with:\n"
+            "   cmake -DTOOLCHAIN_BASE_DIR=/path/to/arm-toolchain-12.3/bin ...")
     endif()
 endif()
 

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -5,24 +5,15 @@ project(MetaModulePluginSDK LANGUAGES C CXX ASM)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/version.cmake)
 
 # Check ARM GCC toolchain version compatibility
-message(STATUS "DEBUG: CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
-message(STATUS "DEBUG: CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "12.3.99")
+    if(NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.2.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.4.0"))
         message(FATAL_ERROR
             "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is not supported.\n"
             "The MetaModule Plugin SDK requires ARM GNU Toolchain 12.2 or 12.3.\n"
-            "Newer versions have incompatibilities with the bundled libstdc++ implementation.\n"
             "Download the correct version from:\n"
             "  https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads\n"
-            "Or specify the toolchain path with:\n"
+            "Specify the toolchain path with:\n"
             "  cmake -DTOOLCHAIN_BASE_DIR=/path/to/arm-toolchain-12.3/bin ...")
-    endif()
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.2.0")
-        message(WARNING
-            "ARM GCC ${CMAKE_CXX_COMPILER_VERSION} is older than the tested version.\n"
-            "The MetaModule Plugin SDK is designed for ARM GNU Toolchain 12.2 or 12.3.\n"
-            "Build may fail or produce unexpected results.")
     endif()
 endif()
 


### PR DESCRIPTION
[I made another PR in the main metamodule project to update docs to use ARM GCC 12.2 or 12.3](https://github.com/4ms/metamodule/pull/561).  This adds a check and gives the user a clear error message about the toolchain version incompatibility.