### PR TITLE
Fix graphic-display doc comments and broken light_idx helper

### DIFF
--- a/core-interface/CoreModules/CoreHelper.hh
+++ b/core-interface/CoreModules/CoreHelper.hh
@@ -61,7 +61,7 @@ struct CoreHelper {
 	}
 
 	template<Elem EL>
-	static constexpr auto light_idx = output_index<EL>();
+	static constexpr auto light_idx = first_light_index<EL>();
 
 	template<Elem EL>
 	static constexpr auto display_index() requires(count(EL).num_lights > 0)

--- a/core-interface/CoreModules/CoreProcessor.hh
+++ b/core-interface/CoreModules/CoreProcessor.hh
@@ -63,7 +63,8 @@ public:
 	//
 	// Parameters:
 	// display_id: the ID of the display (e.g. display_idx<MyDisplay> )
-	// pix_buffer: the buffer to which you should write the pixels when `get_canvas_pixels()` is called (RGBA8888)
+	// pix_buffer: the buffer to which you should write the pixels when draw_graphic_display() is called.
+	//             Pixel format is ARGB8888: (a<<24)|(r<<16)|(g<<8)|b, see PixelRGBA in graphics/pixels.hh
 	// width: the dimensions of the buffer, in pixels. Note: height = pixel_buffer.size() / width
 	// lvgl_canvas: an opaque pointer referring to the drawing context. Safe to ignore. Useful if you are using LVGL to draw.
 	//
@@ -73,7 +74,7 @@ public:
 
 	// Write pixel data to the display's pixel buffer.
 	// The pixel buffer will have been previously passed to the module via show_graphic_display().
-	// If you need to manually access the red, green, blue, and alpha values, use the helper class PixelRGBA in CoreModules/pixels.hh
+	// If you need to manually access the red, green, blue, and alpha values, use the helper class PixelRGBA in graphics/pixels.hh
 	//
 	// This is called in the GUI context.
 	//

--- a/core-interface/graphics/waveform_display.hh
+++ b/core-interface/graphics/waveform_display.hh
@@ -15,12 +15,12 @@ namespace MetaModule
 // (as opposed to displaying a waveform which we know all the values of)
 // The waveform is drawn with the oldest sample at the far left
 // and newer samples progressing to the right.
-// Memory usage is one float per pixels in the x-dimension
+// Memory usage is about one float per pixel in the x-dimension
 //
 // Usage:
 //
 //   struct MyModule : CoreProcessor {
-//     	StreamingWaveformDisplay waveform{100,80}; //100x80 pixel display
+//     	StreamingWaveformDisplay waveform{100,80}; //100mm x 80mm display
 //
 //     	MyModule() {
 //     		waveform.set_wave_color(0x33, 0xFF, 0xBB); //teal

--- a/docs/graphics-helpers.md
+++ b/docs/graphics-helpers.md
@@ -20,7 +20,7 @@ the Rack adaptor.
 
 ```c++
 struct MyModule : CoreProcessor {
-    StreamingWaveformDisplay waveform{100,80}; //100x80 pixel display
+    StreamingWaveformDisplay waveform{100,80}; //100mm x 80mm display
 
     MyModule() {
         waveform.set_wave_color(0x33, 0xFF, 0xBB); //teal


### PR DESCRIPTION
Three small fixes in core-interface docs/helpers:

- CoreProcessor.hh: the show_graphic_display() comment referred to a nonexistent
  get_canvas_pixels() and called the pixel format RGBA8888. The format written by
  PixelRGBA::raw() and read by the firmware's DynamicDisplayDrawer is ARGB8888
  ((a<<24)|(r<<16)|(g<<8)|b). Also corrected the PixelRGBA path (graphics/pixels.hh).
- CoreHelper.hh: light_idx<EL> was defined as output_index<EL>(), so it failed its
  requires-clause for light-only elements and returned the wrong index otherwise.
  Now uses first_light_index<EL>(), matching every other *_idx/*_index() pair.
- StreamingWaveformDisplay: the usage examples said "100x80 pixel display" but the
  constructor takes mm.