### PR TITLE
Add native context-menu API to CoreProcessor

### DIFF
--- a/core-interface/CoreModules/CoreProcessor.hh
+++ b/core-interface/CoreModules/CoreProcessor.hh
@@ -3,6 +3,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <vector>
 
 typedef struct _lv_obj_t lv_obj_t;
 
@@ -90,6 +91,49 @@ public:
 	// This is called in the GUI context.
 	//
 	virtual void hide_graphic_display(int display_id) {
+	}
+
+	// Context menu:
+	//
+	// Override get_context_menu_items() to give your module a context menu, shown in
+	// the GUI when the user opens the module's options. This is the native-module
+	// equivalent of a VCV Rack module's appendContextMenu(). Return an empty vector
+	// (the default) for no menu.
+	//
+	// A single row in the module's context menu.
+	struct ContextMenuItem {
+		enum class Type {
+			Action,	  // Clickable row; invokes context_menu_action(index)
+			Checkbox, // Toggle; shows a checkmark when `checked`; invokes context_menu_action(index)
+			Slider,	  // Continuous 0..1 value; edited via a popup; invokes context_menu_set_value(index, value)
+			Label,	  // Non-interactive text (e.g. a heading)
+			Divider,  // Horizontal separator line
+		};
+
+		Type type = Type::Action;
+		std::string name;		// The row's label
+		bool checked = false;	// Checkbox only: whether the checkmark is shown
+		float value = 0.f;		// Slider only: current value, range 0..1
+		std::string value_text; // Optional text shown after the name (e.g. a Slider's current value)
+	};
+
+	// Return the rows to show in this module's context menu.
+	// Called in the GUI context each time the menu is opened or refreshed, so it is
+	// fine to allocate and to reflect current state (e.g. a Checkbox's `checked`).
+	virtual std::vector<ContextMenuItem> get_context_menu_items() {
+		return {};
+	}
+
+	// Called when the user clicks an Action or Checkbox row. `index` is the row's
+	// position in the vector returned by get_context_menu_items(). A Checkbox handler
+	// should toggle the module's own state; the new state is reflected the next time
+	// get_context_menu_items() is called. Called in the GUI context.
+	virtual void context_menu_action(unsigned index) {
+	}
+
+	// Called repeatedly while the user adjusts a Slider row, with `value` in 0..1.
+	// `index` is the row's position in the vector. Called in the GUI context.
+	virtual void context_menu_set_value(unsigned index, float value) {
 	}
 
 	// Poly:

--- a/docs/coreprocessor.md
+++ b/docs/coreprocessor.md
@@ -197,3 +197,54 @@ not have real-time requirements:
 - For VCV-ported modules, context menus are called by the GUI thread and thus
   are safe to make filesystem calls or memory allocations.
 
+
+## Context menus (native modules)
+
+Native modules can provide a context menu, shown under an "Options" entry at the
+bottom of the module's parameter list in the GUI (the same place a VCV-ported
+module's `appendContextMenu()` items appear). Override three functions:
+
+```c++
+std::vector<ContextMenuItem> get_context_menu_items() override;
+void context_menu_action(unsigned index) override;
+void context_menu_set_value(unsigned index, float value) override;
+```
+
+`get_context_menu_items()` returns the rows to show. Each `ContextMenuItem` has a
+`type`:
+
+- `Action` — a clickable row. Clicking it calls `context_menu_action(index)`.
+- `Checkbox` — shows a checkmark when its `checked` field is true. Clicking it
+  also calls `context_menu_action(index)`; your handler should toggle the
+  module's own state, which is reflected the next time
+  `get_context_menu_items()` is called.
+- `Slider` — a continuous value in the range 0..1 (its `value` field). Clicking it
+  opens a value editor; while the user adjusts it, `context_menu_set_value(index,
+  value)` is called. Use `value_text` to display the current value (e.g. "50%").
+- `Label` — non-interactive text, e.g. a heading.
+- `Divider` — a horizontal separator line.
+
+`index` is the row's position in the vector you returned. These functions are all
+called in the GUI context, so it's safe to allocate memory. Menu-driven state
+changes are a good fit for `save_state()`/`load_state()` if you want them to
+persist with the patch.
+
+A minimal example:
+
+```c++
+std::vector<ContextMenuItem> MyModule::get_context_menu_items() {
+    using Type = ContextMenuItem::Type;
+    return {
+        {.type = Type::Label, .name = "Options"},
+        {.type = Type::Checkbox, .name = "Invert", .checked = inverted},
+    };
+}
+
+void MyModule::context_menu_action(unsigned index) {
+    if (index == 1)
+        inverted = !inverted;
+}
+```
+
+Note: the "Options" entry only appears while the patch is playing.
+


### PR DESCRIPTION
Hey Dan, filling in a stubbed-out feature from the firmware. 

Native (`CoreProcessor`) modules currently have no way to offer a context or "Options" menu — only VCV-ported modules do, via `appendContextMenu()`. This adds an equivalent, header-only API so native modules can present custom options in the GUI.

Three new virtual functions, all with default no-op implementations, so existing modules are unaffected:

- `std::vector<ContextMenuItem> get_context_menu_items()` — returns the menu rows
- `void context_menu_action(unsigned index)` — handles an Action/Checkbox click
- `void context_menu_set_value(unsigned index, float value)` — sets a Slider row's value (0..1)

New nested type `CoreProcessor::ContextMenuItem` with a `Type` of `Action`, `Checkbox`, `Slider`, `Label`, or `Divider`. All are called in the GUI context (safe to allocate). Menu-driven state pairs naturally with the existing `save_state()`/`load_state()` if it should persist with the patch. Docs added to `docs/coreprocessor.md`.

The new virtuals are declared after the existing `CoreProcessor` virtuals, so they extend the vtable rather than reorder it. As with any vtable addition, plugins should be recompiled against the SDK version that includes this — flagging for whatever version/CHANGELOG treatment you prefer.

Companion firmware PR that uses this API: 4ms/metamodule#605

**Files:** `core-interface/CoreModules/CoreProcessor.hh`, `docs/coreprocessor.md`.
