### PR TITLE
Add optional group_name to elements for param submenus

### DIFF
--- a/core-interface/CoreModules/elements/base_element.hh
+++ b/core-interface/CoreModules/elements/base_element.hh
@@ -44,6 +44,12 @@ struct BaseElement {
 	float width_mm = 0;
 	float height_mm = 0;
 
+	// Optional: elements that share the same non-empty group_name are collapsed
+	// into a submenu in the module view's parameter list, to help organize
+	// modules with many controls. Leave empty (the default) for no grouping.
+	// Declared last so existing positional aggregate initializers are unaffected.
+	std::string_view group_name;
+
 	static constexpr size_t NumParams = 0;
 	static constexpr size_t NumLights = 0;
 	static constexpr size_t NumInputs = 0;

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -333,3 +333,28 @@ If your Elements use any dynamically generated strings, then you will also need 
 static storage duration. The Airwindows example does this by having a `std::list<std::string>`, and
 all element names are placed in there. Then the `image` and `short_name` fields of each element are
 set to point to these std::strings in the std::list. See the Airwindows example if you need to do this.
+
+
+## Grouping controls into submenus
+
+Every element has an optional `group_name` field (a `std::string_view` on
+`BaseElement`). Elements that share the same non-empty `group_name` are collapsed
+into a single selectable row in the module view's parameter list; selecting that
+row opens a submenu showing just that group's controls, with a "< Back" row to
+return. This helps organize modules with many parameters. Ungrouped elements
+(the default, empty `group_name`) appear at the top level as before.
+
+```c++
+MetaModule::Knob cutoff;
+cutoff.short_name = "Cutoff";
+cutoff.group_name = "Filter";   // Cutoff and Resonance collapse under a "Filter" submenu
+
+MetaModule::Knob resonance;
+resonance.short_name = "Resonance";
+resonance.group_name = "Filter";
+```
+
+Groups are formed by matching `group_name` strings in element declaration order;
+the group's row appears at the position of its first member. Grouping is purely a
+GUI-organization aid — it does not change param/jack/light indices or the module's
+DSP. Grouping is suspended while the user is patching a cable.


### PR DESCRIPTION
I'm working on a plugin that includes a module with a ton of parameters, and the list gets really long and hard to navigate on MetaModule. This is a feature that would let developers organize parameters into submenus, which will make it easier for users to find what they're looking for without scrolling down dozens of elements.  

Adds an optional `std::string_view group_name` to `BaseElement`. Elements that share the same non-empty `group_name` are collapsed into a submenu in the module view's parameter list (see the companion firmware PR), to help organize modules with many controls. Empty (the default) means no grouping — unchanged behavior. Docs added to `docs/elements.md`.

The field is declared **last** in `BaseElement` on purpose: several info files flatten-initialize the base subobject positionally (e.g. `GraphicDisplay{{x, y, coords, "name", "", w, h}}`), so inserting a field mid-struct would shift `width_mm`/`height_mm`. Appending keeps every existing positional initializer valid.

Companion firmware PR that uses this field: 4ms/metamodule#606

**Files:** `core-interface/CoreModules/elements/base_element.hh`, `docs/elements.md`.
