### PR TITLE
Set module->model in runtime module creation

### DIFF
--- a/rack-interface/include/metamodule/create_model.hh
+++ b/rack-interface/include/metamodule/create_model.hh
@@ -8,9 +8,17 @@
 namespace rack
 {
 
+// Holds the Model registered for each Module/ModuleWidget type, so that
+// create_vcv_module (a captureless function pointer) can set module->model
+template<typename ModuleT, typename ModuleWidgetT>
+struct RegisteredModel {
+	static inline plugin::Model *model = nullptr;
+};
+
 template<typename ModuleT, typename ModuleWidgetT>
 std::unique_ptr<CoreProcessor> create_vcv_module() {
 	auto module = std::make_unique<ModuleT>();
+	module->model = RegisteredModel<ModuleT, ModuleWidgetT>::model;
 	module->module_widget = std::make_shared<ModuleWidgetT>(module.get());
 	return module;
 }
@@ -40,6 +48,7 @@ plugin::Model *createModel(std::string_view slug) {
 
 	plugin::Model *model = new ModelT;
 	model->slug = slug;
+	RegisteredModel<ModuleT, ModuleWidgetT>::model = model;
 	model->creation_func = create_vcv_module<ModuleT, ModuleWidgetT>;
 	return model;
 }

--- a/rack-interface/include/metamodule/create_model.hh
+++ b/rack-interface/include/metamodule/create_model.hh
@@ -18,7 +18,8 @@ struct RegisteredModel {
 template<typename ModuleT, typename ModuleWidgetT>
 std::unique_ptr<CoreProcessor> create_vcv_module() {
 	auto module = std::make_unique<ModuleT>();
-	module->model = RegisteredModel<ModuleT, ModuleWidgetT>::model;
+	// Qualified so it still resolves to Module::model if ModuleT declares its own `model`
+	module->rack::engine::Module::model = RegisteredModel<ModuleT, ModuleWidgetT>::model;
 	module->module_widget = std::make_shared<ModuleWidgetT>(module.get());
 	return module;
 }


### PR DESCRIPTION
Part of 4ms/metamodule#450. Companion PR: metamodule (engine wiring), which bumps this submodule.

`rack::Module::model` is currently only set on the metadata-extraction path (`Model::createModule()` inside `Plugin::addModel`). The runtime creation path — `create_vcv_module<>()`, registered as the factory `creation_func` — never sets it, so every module instance the engine actually runs has `model == nullptr`.

Plugins routinely compare model pointers; all three expander-using plugins this work targets do (`leftExpander.module->model == modelX` in VenomModules and Count Modula, a `Model*` predicate in BogAudio's expander templates), so expander support is impossible without this. It also fixes any other runtime `model` use.

Since `creation_func` is a captureless function pointer (factory ABI, unchanged), the Model* is stashed in a per-instantiation static (`RegisteredModel<ModuleT, ModuleWidgetT>::model`), assigned in `createModel()` before the factory is registered. Header-only change; no ABI impact. Already-compiled plugins keep working as before and pick up the fix when rebuilt.
